### PR TITLE
Adds defaults to Cache Spec and allows key to accept a record containing the file field

### DIFF
--- a/GitLab/CacheKey/Type.dhall
+++ b/GitLab/CacheKey/Type.dhall
@@ -1,0 +1,3 @@
+let CacheKeyFiles = ../CacheKeyFiles/Type.dhall
+
+in  < Files : CacheKeyFiles | Text : Text >

--- a/GitLab/CacheKey/package.dhall
+++ b/GitLab/CacheKey/package.dhall
@@ -1,0 +1,1 @@
+{ Type = ./Type.dhall, toJSON = ./toJSON.dhall }

--- a/GitLab/CacheKey/toJSON.dhall
+++ b/GitLab/CacheKey/toJSON.dhall
@@ -1,0 +1,18 @@
+let Prelude = ../Prelude.dhall
+
+let JSON = Prelude.JSON
+
+let CacheKey = ./Type.dhall
+
+let CacheKeyFiles = ../CacheKeyFiles/package.dhall
+
+let CacheKey/toJSON
+    : CacheKey → JSON.Type
+    = λ(cku : CacheKey) →
+        merge
+          { CacheKeyFiles = λ(c : CacheKeyFiles.Type) → CacheKeyFiles.toJSON c
+          , Text = λ(t : Text) → JSON.string t
+          }
+          cku
+
+in  CacheKey/toJSON

--- a/GitLab/CacheKeyFiles/Type.dhall
+++ b/GitLab/CacheKeyFiles/Type.dhall
@@ -1,0 +1,1 @@
+{ files : List Text, prefix : Optional Text }

--- a/GitLab/CacheKeyFiles/default.dhall
+++ b/GitLab/CacheKeyFiles/default.dhall
@@ -1,0 +1,1 @@
+{ files = [] : List Text, prefix = None Text } : ./Type.dhall

--- a/GitLab/CacheKeyFiles/package.dhall
+++ b/GitLab/CacheKeyFiles/package.dhall
@@ -1,0 +1,1 @@
+{ Type = ./Type.dhall, default = ./default.dhall, toJSON = ./toJSON.dhall }

--- a/GitLab/CacheKeyFiles/toJSON.dhall
+++ b/GitLab/CacheKeyFiles/toJSON.dhall
@@ -1,0 +1,43 @@
+let Prelude = ../Prelude.dhall
+
+let Map = Prelude.Map
+
+let JSON = Prelude.JSON
+
+let CacheKeyFiles = ./Type.dhall
+
+let dropNones = ../utils/dropNones.dhall
+
+let Optional/map = Prelude.Optional.map
+
+let List/map = Prelude.List.map
+
+let stringsArray
+    : List Text → JSON.Type
+    = λ(xs : List Text) →
+        JSON.array (Prelude.List.map Text JSON.Type JSON.string xs)
+
+in  let CacheKeyFiles/toJSON
+        : CacheKeyFiles → JSON.Type
+        = λ(ck : CacheKeyFiles) →
+            let obj
+                : Map.Type Text (Optional JSON.Type)
+                = toMap
+                    { files =
+                        if    Prelude.List.null Text ck.files
+                        then  None JSON.Type
+                        else  Some
+                                ( JSON.array
+                                    ( Prelude.List.map
+                                        Text
+                                        JSON.Type
+                                        JSON.string
+                                        ck.files
+                                    )
+                                )
+                    , prefix = Optional/map Text JSON.Type JSON.string ck.prefix
+                    }
+
+            in  JSON.object (dropNones Text JSON.Type obj)
+
+    in  CacheKeyFiles/toJSON

--- a/GitLab/CacheSpec/Type.dhall
+++ b/GitLab/CacheSpec/Type.dhall
@@ -2,7 +2,9 @@ let When = ../When/Type.dhall
 
 let CachePolicy = ../CachePolicy/Type.dhall
 
-in  { key : Text
+let CacheKey = ../CacheKey/Type.dhall
+
+in  { key : Optional CacheKey
     , paths : List Text
     , untracked : Optional Bool
     , when : When

--- a/GitLab/CacheSpec/default.dhall
+++ b/GitLab/CacheSpec/default.dhall
@@ -2,4 +2,12 @@ let When = ../When/Type.dhall
 
 let CachePolicy = ../CachePolicy/Type.dhall
 
-in  { untracked = None Bool, when = When.OnSuccess, policy = None CachePolicy }
+let CacheKey = ../CacheKey/Type.dhall
+
+in    { key = None CacheKey
+      , when = When.OnSuccess
+      , paths = [] : List Text
+      , untracked = None Bool
+      , policy = None CachePolicy
+      }
+    : ./Type.dhall

--- a/GitLab/CacheSpec/toJSON.dhall
+++ b/GitLab/CacheSpec/toJSON.dhall
@@ -6,6 +6,13 @@ let JSON = Prelude.JSON
 
 let CacheSpec = ./Type.dhall
 
+let CacheKey = ../CacheKey/package.dhall
+
+let stringsArray
+    : List Text → JSON.Type
+    = λ(xs : List Text) →
+        JSON.array (Prelude.List.map Text JSON.Type JSON.string xs)
+
 let dropNones = ../utils/dropNones.dhall
 
 let Optional/map = Prelude.Optional.map
@@ -16,14 +23,28 @@ in  let CacheSpec/toJSON
         : CacheSpec → JSON.Type
         = λ(cs : CacheSpec) →
             let obj
-                : Map.Type Text JSON.Type
+                : Map.Type Text (Optional JSON.Type)
                 = toMap
-                    { key = JSON.string cs.key
+                    { key =
+                        Optional/map
+                          CacheKey.Type
+                          JSON.Type
+                          CacheKey.toJSON
+                          cs.key
                     , paths =
-                        JSON.array
-                          (List/map Text JSON.Type JSON.string cs.paths)
+                        if    Prelude.List.null Text cs.paths
+                        then  None JSON.Type
+                        else  Some
+                                ( JSON.array
+                                    ( List/map
+                                        Text
+                                        JSON.Type
+                                        JSON.string
+                                        cs.paths
+                                    )
+                                )
                     }
 
-            in  JSON.object obj
+            in  JSON.object (dropNones Text JSON.Type obj)
 
     in  CacheSpec/toJSON

--- a/GitLab/package.dhall
+++ b/GitLab/package.dhall
@@ -22,4 +22,6 @@
 , Defaults = ./Defaults/package.dhall
 , Service = ./Service/package.dhall
 , CachePolicy = ./CachePolicy/package.dhall
+, CacheKey = ./CacheKey/package.dhall
+, CacheKeyFiles = ./CacheKeyFiles/package.dhall
 }


### PR DESCRIPTION
This PR creates a`default.dhall` file for CacheSpec. It also allows CacheSpec's key field to accept a new record CacheKeyFiles which consists of field `prefix` and `files`. This was created to allow key generation from files, the keys filed in the CacheSpec will now accept a record instead of String.